### PR TITLE
Add interface for bindInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "form-container",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Lightweight React form container with validation (written in TypeScript)",
     "keywords": [
         "react",

--- a/src/FormContainer.tsx
+++ b/src/FormContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { flow, isNil } from 'lodash';
 import * as validation from './validate';
-import { IFormConfig } from './interfaces';
+import { IFormConfig, IBoundInput } from './interfaces';
 
 const hoistNonReactStatics = require('hoist-non-react-statics');
 
@@ -59,7 +59,7 @@ const makeWrapper = <T extends {}>(config: IFormConfig) => (WrappedComponent: an
             return '';
         }
 
-        bindToChangeEvent = (e: React.ChangeEvent<any>) => {
+        bindToChangeEvent = (e: React.ChangeEvent<any>): void => {
             const { name, type } = e.target;
             let { value } = e.target;
 
@@ -75,10 +75,10 @@ const makeWrapper = <T extends {}>(config: IFormConfig) => (WrappedComponent: an
             this.setProperty(name, value);
         }
 
-        bindToFocusEvent = (e: React.FocusEvent<any>) => {
+        bindToFocusEvent = (e: React.FocusEvent<any>): void => {
         }
 
-        bindToBlurEvent = (e: React.FocusEvent<any>) => {
+        bindToBlurEvent = (e: React.FocusEvent<any>): void => {
             const target = e.target as HTMLInputElement;
             this.setFieldToTouched(target.name as keyof T);
 
@@ -87,7 +87,7 @@ const makeWrapper = <T extends {}>(config: IFormConfig) => (WrappedComponent: an
             }
         }
 
-        bindInput = (name: keyof T) => ({
+        bindInput = (name: keyof T): IBoundInput => ({
             name,
             value: this.getValue(name),
             onChange: this.bindToChangeEvent,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -12,6 +12,25 @@ export type ValidationRule = <T = any>(prop: keyof T, errorMessage: string, attr
     ErrorMessage
 ];
 
+export interface IBoundInput<T = any> {
+    name: string;
+    value: (name: keyof T) => string;
+    onChange: (e: React.ChangeEvent<any>) => void;
+    onFocus: (e: React.FocusEvent<any>) => void;
+    onBlur: (e: React.FocusEvent<any>) => void;
+    ref: (input: any) => void;
+}
+
+export interface IFormMethods<T = any> {
+    bindInput: (name: string) => IBoundInput<T>;
+    bindToChangeEvent: (e: React.ChangeEvent<any>) => void;
+    setProperty: (prop: keyof T, value: T[keyof T]) => any;
+    setModel: (model: {
+        [name in keyof T]?: any
+    }) => any;
+    setFieldToTouched: (prop: keyof T) => any;
+}
+
 export interface IFormProps<T = any> {
     form: {
         model: any;
@@ -20,15 +39,7 @@ export interface IFormProps<T = any> {
         validationErrors: { [key: string]: string };
         touched: { [key: string]: boolean };
     };
-    formMethods: {
-        bindInput: (name: string) => any;
-        bindToChangeEvent: (e: React.ChangeEvent<any>) => void;
-        setProperty: (prop: keyof T, value: T[keyof T]) => any;
-        setModel: (model: {
-            [name in keyof T]?: any
-        }) => any;
-        setFieldToTouched: (prop: keyof T) => any;
-    };
+    formMethods: IFormMethods<T>;
     initialModel?: any;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,16 +93,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
-ajv@^5.1.5:
+ajv@^5.1.0, ajv@^5.1.5:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.4.0.tgz#32d1cf08dbc80c432f426f12e10b2511f6b46474"
   dependencies:


### PR DESCRIPTION
#### What's this PR do?
Adds an interface for `bindInput`.

#### Where should the reviewer start?
FormContainer.tsx

#### What are the relevant tickets / issues?
#18 

#### How should this be manually tested?
There is no functional change, so manually test that all works as it did previously.

#### Any background context you want to provide?
The idea for this is when `bindInput` needs to be passed down as a prop, the type definition can be defined.

#### Questions
Will this be exported (and thus importable) in the npm package?
