### PR TITLE
BoundInput value is a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "form-container",
-    "version": "0.1.1",
+    "version": "0.1.3",
     "description": "Lightweight React form container with validation (written in TypeScript)",
     "keywords": [
         "react",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,7 +14,7 @@ export type ValidationRule = <T = any>(prop: keyof T, errorMessage: string, attr
 
 export interface IBoundInput<T = any> {
     name: string;
-    value: (name: keyof T) => string;
+    value: string;
     onChange: (e: React.ChangeEvent<any>) => void;
     onFocus: (e: React.FocusEvent<any>) => void;
     onBlur: (e: React.FocusEvent<any>) => void;


### PR DESCRIPTION
#### What's this PR do?
Corrects the type for `value` on `IBoundInput`.

It was incorrectly set to `(name: keyof T) => string` but is simply a `string`.

#### Where should the reviewer start?
* src/interfaces.ts

#### Issue
#17 