### PR TITLE
Update middleware interface to return a value

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -41,8 +41,8 @@ export interface IFormProps<T = any> {
     initialModel?: any;
 }
 
-export interface IFormConfig<T = any> {
+export interface IFormConfig<T = object, M = object> {
     initialModel?: Partial<T>;
     onInputBlur?: (e: React.FocusEvent<any>) => any;
-    middleware?: (props: T) => any;
+    middleware?: (props: T) => T & M;
 }


### PR DESCRIPTION
#### What's this PR do?
Adds a return type for the middleware function.

#### Where should the reviewer start?
* interfaces.ts

#### How should this be manually tested?
Best to reproduce the code in the example in #27 by using a middleware function that returns `console.log`. This will not work because the expected behaviour is that the middleware will take it a model, and returns a transformed model and `console.log` is a void which will render the state as undefined.

#### Any background context you want to provide?
Issue raised in #27 

#### What are the relevant tickets / issues?
#27

#### Questions
What is middleware meant to do here? If it's meant to possible extend the model I thought about this approach as well...

```
export interface IFormConfig<T = any, M = any> {
    initialModel?: Partial<T>;
    onInputBlur?: (e: React.FocusEvent<any>) => any;
    middleware?: (props: T) => T & M;
}
```

And also `any` seems to be strange here because it does need to be at least some sort of object for this to work. I wonder if we might consider replacing the `any` for `object`.

```
export interface IFormConfig<T = {}, M = {}> {
    initialModel?: Partial<T>;
    onInputBlur?: (e: React.FocusEvent<any>) => any;
    middleware?: (props: T) => T & M;
}
```

Thoughts? I suppose it depends on what we're trying to achieve here. I final consideration would be to simply delete `middleware` as I'm not currently seeing its potential.