### PR TITLE
Check for stateless function before using ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ export class Form extends React.Component<IProps, {}> {
 
     render() {
         const { validationErrors, touched } = this.props.form;
-        const { bindInput } = this.props.formMethods;
+        const { bindInput, bindNativeInput } = this.props.formMethods;
         return (
             <form onSubmit={this.handleSubmit}>
                 <div>
@@ -71,9 +71,9 @@ export class Form extends React.Component<IProps, {}> {
                         Required field
                         <input
                             {/* HTML attribute to validate required field */}
-                            required="true"
+                            required={true}
                             {/* this is how you bind input to a form-container */}
-                            {...bindInput('test')}
+                            {...bindNativeInput('test')}
                         />
                         <small>{touched.test && validationErrors.test}</small>
                     </label>

--- a/src/FormContainer.tsx
+++ b/src/FormContainer.tsx
@@ -74,8 +74,12 @@ const makeWrapper = <T extends {}>(config: IFormConfig) => (WrappedComponent: an
             value: this.getValue(name),
             onChange: this.bindToChangeEvent,
             onFocus: this.bindToFocusEvent,
-            onBlur: this.bindToBlurEvent,
-            ref: (input: any) => {
+            onBlur: this.bindToBlurEvent
+        });
+
+        bindNativeInput = (name: keyof T): IBoundInput => ({
+            ...this.bindInput(name),
+            ref: (input: HTMLInputElement) => {
                 if (!this.state.inputs[name]) {
                     this.setState({
                         inputs: {
@@ -96,6 +100,7 @@ const makeWrapper = <T extends {}>(config: IFormConfig) => (WrappedComponent: an
                 },
                 formMethods: {
                     bindInput: this.bindInput,
+                    bindNativeInput: this.bindNativeInput,
                     bindToChangeEvent: this.bindToChangeEvent,
                     setProperty: this.setProperty,
                     setModel: this.setModel,

--- a/src/__tests__/FormContainer.test.tsx
+++ b/src/__tests__/FormContainer.test.tsx
@@ -6,123 +6,163 @@ import * as validation from '../validate';
 import { isRequired } from '../validators';
 
 const setupTest = (formConfig = {}, validators = []) => {
-  const MockComponent = ({ formMethods: { bindInput }, form }) => (
-    <form>
-      <input {...bindInput('foo') } />
-    </form>
-  );
-  const WrapperComponent = connectForm(validators, formConfig)(MockComponent);
-  const wrapperComponent = mount(
-    <WrapperComponent />
-  );
-  const wrappedComponent = wrapperComponent.find(MockComponent);
-  const input = wrapperComponent.find('input');
+    const MockComponent = ({ formMethods: { bindInput, bindNativeInput }, form }) => (
+        <form>
+            <input {...bindInput('foo')} />
+            <input {...bindNativeInput('nativeFoo')} />
+        </form>
+    );
+    const WrapperComponent = connectForm(validators, formConfig)(MockComponent);
+    const wrapperComponent = mount(<WrapperComponent />);
+    const wrappedComponent = wrapperComponent.find(MockComponent);
+    const input = wrapperComponent.find('[name="foo"]');
+    const nativeInput = wrapperComponent.find('[name="nativeFoo"]');
 
-  return {
-    wrapperComponent,
-    wrappedComponent,
-    input
-  };
+    return {
+        input,
+        nativeInput,
+        wrappedComponent,
+        wrapperComponent
+    };
 };
 
 describe('Form container', () => {
-  it('should export connectForm function by default', () => {
-    expect(connectForm).toBeDefined;
-  });
-
-  it('should call validate function', () => {
-    const mock = jest.fn(rules => component => component);
-    (validation as any).validate = jest.fn(rules => component => component);
-    const { wrappedComponent } = setupTest({}, [ isRequired ]);
-    expect(validation.validate).toHaveBeenCalledTimes(1);
-    expect(validation.validate).toHaveBeenCalledWith([ isRequired ]);
-    mock.mockClear();
-  });
-
-  describe('render', () => {
-    it('should render the wrapped component', () => {
-      const { wrappedComponent } = setupTest();
-      expect(wrappedComponent.length).toEqual(1);
+    it('should export connectForm function by default', () => {
+        expect(connectForm).toBeDefined;
     });
 
-    it('should set initial state', () => {
-      const { wrapperComponent } = setupTest();
-      const state: any = wrapperComponent.state();
-
-      expect(state.model).toEqual({});
-      expect(state.touched).toEqual({});
-      expect(Object.keys(state.inputs)).toEqual(['foo']);
+    it('should call validate function', () => {
+        const mock = jest.fn(rules => component => component);
+        (validation as any).validate = jest.fn(rules => component => component);
+        const { wrappedComponent } = setupTest({}, [isRequired]);
+        expect(validation.validate).toHaveBeenCalledTimes(1);
+        expect(validation.validate).toHaveBeenCalledWith([isRequired]);
+        mock.mockClear();
     });
 
-    it('should render the input', () => {
-      const { input } = setupTest();
-      expect(input.length).toEqual(1);
+    describe('render', () => {
+        it('should render the wrapped component', () => {
+            const { wrappedComponent } = setupTest();
+            expect(wrappedComponent.length).toEqual(1);
+        });
+
+        it('should set initial state', () => {
+            const { wrapperComponent } = setupTest();
+            const state: any = wrapperComponent.state();
+
+            expect(state.model).toEqual({});
+            expect(state.touched).toEqual({});
+            expect(Object.keys(state.inputs)).toEqual(['nativeFoo']);
+        });
+
+        it('should render the input', () => {
+            const { input } = setupTest();
+            expect(input.length).toEqual(1);
+        });
     });
 
     describe('wrapper props', () => {
-      it('should have required form props', () => {
-        const { wrapperComponent, wrappedComponent, input } = setupTest();
-        const requiredProps: ReadonlyArray<string> = ['model', 'inputs', 'touched'];
+        it('should have required form props', () => {
+            const { wrapperComponent, wrappedComponent, input } = setupTest();
+            const requiredProps: ReadonlyArray<string> = ['model', 'inputs', 'touched'];
 
-        expect(wrappedComponent.props()).toHaveProperty('form');
-        requiredProps.forEach(prop => expect(wrappedComponent.props().form).toHaveProperty(prop))
-      });
+            expect(wrappedComponent.props()).toHaveProperty('form');
+            requiredProps.forEach(prop =>
+                expect(wrappedComponent.props().form).toHaveProperty(prop)
+            );
+        });
 
-      it('should have required formMethods props', () => {
-        const { wrapperComponent, wrappedComponent, input } = setupTest();
-        const requiredProps: ReadonlyArray<string> = ['bindInput', 'bindToChangeEvent', 'setProperty', 'setModel', 'setFieldToTouched'];
+        it('should have required formMethods props', () => {
+            const { wrapperComponent, wrappedComponent, input } = setupTest();
+            const requiredProps: ReadonlyArray<string> = [
+                'bindInput',
+                'bindNativeInput',
+                'bindToChangeEvent',
+                'setFieldToTouched',
+                'setModel',
+                'setProperty'
+            ];
 
-        expect(wrappedComponent.props()).toHaveProperty('formMethods');
-        requiredProps.forEach(prop => expect(wrappedComponent.props().formMethods).toHaveProperty(prop))
-      });
+            expect(wrappedComponent.props()).toHaveProperty('formMethods');
+            requiredProps.forEach(prop =>
+                expect(wrappedComponent.props().formMethods).toHaveProperty(prop)
+            );
+        });
     });
 
     describe('bindInput', () => {
-      it('should have an input with a name and a value', () => {
-        const { input } = setupTest();
-        expect(input.prop('name')).toEqual('foo');
-        expect(input.prop('value')).toEqual('');
-      });
+        it('should have an input with a name and a value', () => {
+            const { input } = setupTest();
+            expect(input.prop('name')).toEqual('foo');
+            expect(input.prop('value')).toEqual('');
+        });
 
-      it('should change the value of the input', () => {
-        const { wrapperComponent, input } = setupTest();
-        const newValue = 'apples';
+        it('should change the value of the input', () => {
+            const { wrapperComponent, input } = setupTest();
+            const newValue = 'apples';
 
-        expect(input.prop('value')).toEqual('');
-        input.simulate('change', { target: { name: input.prop('name'), value: newValue } });
-        const updatedInput = wrapperComponent.find('input');
-        expect(updatedInput.prop('value')).toEqual(newValue);
-      });
+            expect(input.prop('value')).toEqual('');
+            input.simulate('change', { target: { name: input.prop('name'), value: newValue } });
+            const updatedInput = wrapperComponent.find('[name="foo"]');
+            expect(updatedInput.prop('value')).toEqual(newValue);
+        });
 
-      it('should set field to touched on blur', () => {
-        const { wrapperComponent, input } = setupTest();
+        it('should set field to touched on blur', () => {
+            const { wrapperComponent, input } = setupTest();
 
-        expect(wrapperComponent.state('touched')).toEqual({});
-        input.simulate('blur');
-        expect(wrapperComponent.state('touched')).toEqual({ foo: true });
-      });
+            expect(wrapperComponent.state('touched')).toEqual({});
+            input.simulate('blur');
+            expect(wrapperComponent.state('touched')).toEqual({ foo: true });
+        });
+    });
+
+    describe('bindNativeInput', () => {
+        it('should have an input with a name and a value', () => {
+            const { nativeInput } = setupTest();
+            expect(nativeInput.prop('name')).toEqual('nativeFoo');
+            expect(nativeInput.prop('value')).toEqual('');
+        });
+
+        it('should change the value of the input', () => {
+            const { wrapperComponent, nativeInput } = setupTest();
+            const newValue = 'apples';
+
+            expect(nativeInput.prop('value')).toEqual('');
+            nativeInput.simulate('change', {
+                target: { name: nativeInput.prop('name'), value: newValue }
+            });
+            const updatedInput = wrapperComponent.find('[name="nativeFoo"]');
+            expect(updatedInput.prop('value')).toEqual(newValue);
+        });
+
+        it('should set field to touched on blur', () => {
+            const { wrapperComponent, nativeInput } = setupTest();
+
+            expect(wrapperComponent.state('touched')).toEqual({});
+            nativeInput.simulate('blur');
+            expect(wrapperComponent.state('touched')).toEqual({ nativeFoo: true });
+        });
     });
 
     describe('formConfig', () => {
-      it('should should set initial model when it is provided', () => {
-        const foo = 'bananas';
-        const initialModel = { foo }
-        const { input } = setupTest({ initialModel });
-        expect(input.prop('value')).toEqual(foo);
-      });
+        it('should should set initial model when it is provided', () => {
+            const foo = 'bananas';
+            const initialModel = { foo };
+            const { input } = setupTest({ initialModel });
+            expect(input.prop('value')).toEqual(foo);
+        });
 
-      it('should call custom onInputBlur when it is provided', () => {
-        const onInputBlur = jest.fn();
-        const { wrapperComponent, input } = setupTest({ onInputBlur });
-        input.simulate('blur');
-        expect(onInputBlur).toHaveBeenCalled;
-      });
+        it('should call custom onInputBlur when it is provided', () => {
+            const onInputBlur = jest.fn();
+            const { wrapperComponent, input } = setupTest({ onInputBlur });
+            input.simulate('blur');
+            expect(onInputBlur).toHaveBeenCalled;
+        });
 
-      it('should call middleware when it is provided', () => {
-        const middleware = (props: any) => ({ ...props, bar: 'baz' });
-        const { wrappedComponent } = setupTest({ middleware });
-        expect(wrappedComponent.props()).toHaveProperty('bar');
-      });
+        it('should call middleware when it is provided', () => {
+            const middleware = (props: any) => ({ ...props, bar: 'baz' });
+            const { wrappedComponent } = setupTest({ middleware });
+            expect(wrappedComponent.props()).toHaveProperty('bar');
+        });
     });
-  })
 });


### PR DESCRIPTION
#### What's this PR do?
Adds a check for a stateless function component before applying the `ref` property in the `bindInput` method. The check is simply whether there is a render method in the current instance. Solution found here: https://stackoverflow.com/questions/41488713/react-how-to-determine-if-component-is-stateless-functional

#### Where should the reviewer start?
* Check the `bindInput` method in FormContainer.tsx

#### How should this be manually tested?
* Apply the `bindInput` method to a stateless function component.

#### What are the relevant tickets / issues?
#28 
