### PR TITLE
Breaking change: Adds warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
   - npm test
   - npm run test:coverage
   - npm run build
+  - cd examples && npm install && npm build
 cache:
   directories:
     - node_modules

--- a/examples/src/Form.tsx
+++ b/examples/src/Form.tsx
@@ -7,9 +7,7 @@ import { isRequired } from '../../src/validators';
 
 export interface IProps extends IFormProps {}
 
-export const Form: React.SFC<IProps> = props => {
-    const { bindInput } = props.formMethods;
-    console.log('<<<', props);
+export const Form: React.SFC<IProps> = ({ form, form: { errors }, formMethods: { bindInput } }) => {
     return (
         <div className={styles.view}>
             <div className={styles.form}>
@@ -18,35 +16,26 @@ export const Form: React.SFC<IProps> = props => {
                     <label className={styles.label}>
                         Username:
                         <input {...bindInput('username')} />
-                        <span className={styles.error}>
-                            {props.form.validationErrors['username']}
-                        </span>
+                        <span className={styles.error}>{errors['username']}</span>
                     </label>
                     <label className={styles.label}>
                         Password:
                         <input type="password" {...bindInput('password')} />
-                        <span className={styles.error}>
-                            {props.form.validationErrors['password']}
-                        </span>
+                        <span className={styles.error}>{errors['password']}</span>
                     </label>
                 </form>
             </div>
             <div className={styles.json}>
-                <JSONTree data={props.form} />
+                <JSONTree data={form} />
             </div>
         </div>
     );
 };
 
-export const ConnectedForm = connectForm<IProps>(
-    [isRequired('username', 'please enter your username')],
-    {
-        middleware: props => {
-            console.log('>>>', props);
-            return {
-                ...props,
-                test: 'one'
-            };
-        }
-    }
-)(Form);
+export const ConnectedForm = connectForm<IProps>({
+    errors: [isRequired('username', 'please enter your username')],
+    middleware: props => ({
+        ...props,
+        test: 'one'
+    })
+})(Form);

--- a/src/FormContainer.tsx
+++ b/src/FormContainer.tsx
@@ -118,4 +118,4 @@ const makeWrapper = <T extends {}>(config: IFormConfig) => (WrappedComponent: an
 };
 
 export const connectForm = <T extends {} = any>(config: IFormConfig<T> = {}) => (Component: any) =>
-    flow([validation.validate(config.validators), makeWrapper<T>(config)])(Component);
+    flow([validation.validate(config), makeWrapper<T>(config)])(Component);

--- a/src/FormContainer.tsx
+++ b/src/FormContainer.tsx
@@ -117,7 +117,5 @@ const makeWrapper = <T extends {}>(config: IFormConfig) => (WrappedComponent: an
     return hoistNonReactStatics(FormWrapper, WrappedComponent);
 };
 
-export const connectForm = <T extends {} = any>(
-    validators: any[] = [],
-    config: IFormConfig<T> = {}
-) => (Component: any) => flow([validation.validate(validators), makeWrapper<T>(config)])(Component);
+export const connectForm = <T extends {} = any>(config: IFormConfig<T> = {}) => (Component: any) =>
+    flow([validation.validate(config.validators), makeWrapper<T>(config)])(Component);

--- a/src/__tests__/FormContainer.test.tsx
+++ b/src/__tests__/FormContainer.test.tsx
@@ -5,14 +5,14 @@ import { connectForm } from '../FormContainer';
 import * as validation from '../validate';
 import { isRequired } from '../validators';
 
-const setupTest = (formConfig = {}, validators = []) => {
+const setupTest = (formConfig = {}) => {
     const MockComponent = ({ formMethods: { bindInput, bindNativeInput }, form }) => (
         <form>
             <input {...bindInput('foo')} />
             <input {...bindNativeInput('nativeFoo')} />
         </form>
     );
-    const WrapperComponent = connectForm(validators, formConfig)(MockComponent);
+    const WrapperComponent = connectForm(formConfig)(MockComponent);
     const wrapperComponent = mount(<WrapperComponent />);
     const wrappedComponent = wrapperComponent.find(MockComponent);
     const input = wrapperComponent.find('[name="foo"]');
@@ -34,7 +34,7 @@ describe('Form container', () => {
     it('should call validate function', () => {
         const mock = jest.fn(rules => component => component);
         (validation as any).validate = jest.fn(rules => component => component);
-        const { wrappedComponent } = setupTest({}, [isRequired]);
+        const { wrappedComponent } = setupTest({ validators: [isRequired] });
         expect(validation.validate).toHaveBeenCalledTimes(1);
         expect(validation.validate).toHaveBeenCalledWith([isRequired]);
         mock.mockClear();

--- a/src/__tests__/FormContainer.test.tsx
+++ b/src/__tests__/FormContainer.test.tsx
@@ -31,12 +31,21 @@ describe('Form container', () => {
         expect(connectForm).toBeDefined;
     });
 
-    it('should call validate function', () => {
+    it('should call error validate function', () => {
         const mock = jest.fn(rules => component => component);
         (validation as any).validate = jest.fn(rules => component => component);
-        const { wrappedComponent } = setupTest({ validators: [isRequired] });
+        const { wrappedComponent } = setupTest({ errors: [isRequired] });
         expect(validation.validate).toHaveBeenCalledTimes(1);
-        expect(validation.validate).toHaveBeenCalledWith([isRequired]);
+        expect(validation.validate).toHaveBeenCalledWith({ errors: [isRequired] });
+        mock.mockClear();
+    });
+
+    it('should call warning validate function', () => {
+        const mock = jest.fn(rules => component => component);
+        (validation as any).validate = jest.fn(rules => component => component);
+        const { wrappedComponent } = setupTest({ warnings: [isRequired] });
+        expect(validation.validate).toHaveBeenCalledTimes(1);
+        expect(validation.validate).toHaveBeenCalledWith({ warnings: [isRequired] });
         mock.mockClear();
     });
 

--- a/src/__tests__/validate.test.tsx
+++ b/src/__tests__/validate.test.tsx
@@ -6,59 +6,61 @@ import { isRequired } from '../validators';
 const hoistNonReactStatics = require('hoist-non-react-statics');
 
 describe('Validation', () => {
-  
-  describe('validate', () => {
-    
-    it('should return a valid result of validationFn execution', () => {
-      const MockComponent = ({ formMethods: { bindInput }, form }) => (
-        <form>
-        <input {...bindInput('foo') } />
-        </form>
-      );
-      const props = {
-        form: {
-          model: {
-            foo: 'test'
-          }
-        }
-      };
-      const result = validation.validate([])(MockComponent as any)(props);
-      expect(result.props).toEqual({
-        form: {
-          isValid: true,
-          model: {
-            foo: 'test'
-          },
-          validationErrors: {}
-        }
-      });
-    });
+    describe('validate', () => {
+        it('should return a valid result of validationFn execution', () => {
+            const MockComponent = ({ formMethods: { bindInput }, form }) => (
+                <form>
+                    <input {...bindInput('foo')} />
+                </form>
+            );
+            const props = {
+                form: {
+                    model: {
+                        foo: 'test'
+                    }
+                }
+            };
+            const result = validation.validate({})(MockComponent as any)(props);
+            expect(result.props).toEqual({
+                form: {
+                    isValid: true,
+                    model: {
+                        foo: 'test'
+                    },
+                    errors: {},
+                    warnings: {}
+                }
+            });
+        });
 
-    it('should return a invalid result of validationFn execution', () => {
-      const MockComponent = ({ formMethods: { bindInput }, form }) => (
-        <form>
-        <input {...bindInput('foo') } />
-        </form>
-      );
-      const props = {
-        form: {
-          model: {
-            foo: ''
-          }
-        }
-      };
-      const result = validation.validate([ isRequired('foo', 'Required field') ])(MockComponent as any)(props);
-      expect(result.props).toEqual({
-        form: {
-          isValid: false,
-          model: {
-            foo: ''
-          },
-          validationErrors: {
-            foo: 'Required field'
-          }
-        }
-      });
+        it('should return a invalid result of validationFn execution', () => {
+            const MockComponent = ({ formMethods: { bindInput }, form }) => (
+                <form>
+                    <input {...bindInput('foo')} />
+                </form>
+            );
+            const props = {
+                form: {
+                    model: {
+                        foo: ''
+                    }
+                }
+            };
+            const result = validation.validate({ errors: [isRequired('foo', 'Required field')] })(
+                MockComponent as any
+            )(props);
+            expect(result.props).toEqual({
+                form: {
+                    isValid: false,
+                    model: {
+                        foo: ''
+                    },
+                    errors: {
+                        foo: 'Required field'
+                    },
+                    warnings: {}
+                }
+            });
+        });
     });
-  });
-})
+});

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -45,4 +45,5 @@ export interface IFormConfig<T = object, M = object> {
     initialModel?: Partial<T>;
     onInputBlur?: (e: React.FocusEvent<any>) => any;
     middleware?: (props: T) => T & M;
+    validators?: ValidationRule[];
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -34,7 +34,8 @@ export interface IFormProps<T = any> {
         model: any;
         inputs: any;
         isValid?: boolean;
-        validationErrors: { [key: string]: string };
+        errors: { [key: string]: string };
+        warnings: { [key: string]: string };
         touched: { [key: string]: boolean };
     };
     formMethods: IFormMethods<T>;
@@ -45,5 +46,6 @@ export interface IFormConfig<T = object, M = object> {
     initialModel?: Partial<T>;
     onInputBlur?: (e: React.FocusEvent<any>) => any;
     middleware?: (props: T) => T & M;
-    validators?: ValidationRule[];
+    errors?: ValidationRule[];
+    warnings?: ValidationRule[];
 }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -8,9 +8,6 @@ export const ValidationRuleFactory: any = (
     { [prop]: message }
 ];
 
-export const isRequired: ValidationRule = ValidationRuleFactory(
-    (value: any) => !!value,
-    'Required field'
-);
+export const isRequired = ValidationRuleFactory((value: any) => !!value, 'Required field');
 
-export const hasError: ValidationRule = ValidationRuleFactory((value: any) => false, 'Error');
+export const hasError = ValidationRuleFactory((value: any) => false, 'Error');


### PR DESCRIPTION
#### What's this PR do?
This pull request adds the concept of warnings to complement the errors that already exist.

#### Where should the reviewer start?
* The biggest (breaking) change is that `validations` no longer exists as the first parameter in `connectForm`. This is because we wouldn't know whether or not the validations should apply to the `errors` or `warnings` object.

#### How should this be manually tested?
* Ideally check out the example form, which has been updated. I still can't get it to build 😞but I have updated it.

#### What are the relevant tickets / issues?
#33 

#### Questions
Any suggestions for improvement? I think I could add more documentation around the warnings, especially in the example.