### PR TITLE
Add warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ Form container is a lightweight React form container with validation (written in
 It allows you to use both HTML5 form validation and custom validation functions.
 
 It provides your child form with 2 objects of props:
-- `form` - all data on your form values, states and errors
-- `formMethods` - methods to bind you input controllers and manipulate the form model
+
+*   `form` - all data on your form values, states and errors
+*   `formMethods` - methods to bind you input controllers and manipulate the form model
 
 ## Installation
+
 Form Container is available as the `form-container` package on npm.
 
 Install it in your project with `npm` or `yarn`
@@ -17,7 +19,9 @@ Install it in your project with `npm` or `yarn`
 ```bash
 npm install form-container
 ```
+
 or
+
 ```bash
 yarn add form-container
 ```
@@ -25,23 +29,25 @@ yarn add form-container
 ## Getting started
 
 <a id="connectForm"></a>
+
 ### `connectForm([validators], [formConfig])(WrappedComponent)`
+
 `form-container` exposes `connectForm` function to connect an arbitrary form component (`WrappedComponent`).
-It does not modify the component class passed to it; instead, it *returns* a new, connected component class for you to use.
+It does not modify the component class passed to it; instead, it _returns_ a new, connected component class for you to use.
 
 <a id="connect-form-arguments"></a>
+
 #### Arguments
 
-* [`validators: ValidationRule[]`] \(*Array*): An array of rules can be provided to validate the form model against them. Rules are executed in a sequence that is defined in the array.  
+*   [`validators: ValidationRule[]`] \(_Array_): An array of rules can be provided to validate the form model against them. Rules are executed in a sequence that is defined in the array.
 
-* [`formConfig: IFormConfig`] \(*Object*): An object contains initial configuration for the form  
+*   [`formConfig: IFormConfig`] \(_Object_): An object contains initial configuration for the form
 
-    - `initialModel: Partial<T>` — object provides initial values to the form fields
-    - `middleware: (props: T) => any` — function transforms props passed to the wrapped component
-    - `onInputBlur: (e: React.ForcusEvent<any>) => any` — function is called on every blur on an input field within the form. Adding a custom `onBlur` to the input field itself is not recommended, use this method instead
+    *   `initialModel: Partial<T>` — object provides initial values to the form fields
+    *   `middleware: (props: T) => T & M` — function transforms props passed to the wrapped component
+    *   `onInputBlur: (e: React.ForcusEvent<any>) => void` — function is called on every blur on an input field within the form. Adding a custom `onBlur` to the input field itself is not recommended, use this method instead
 
 ## Validation
-
 
 ### HTML5 validation example
 
@@ -100,6 +106,7 @@ export default connectForm(validators, formConfig)(Form);
 ```
 
 ### Custom validation example
+
 ```javascript
 // components/Form.tsx
 import * as React from 'react';
@@ -130,15 +137,16 @@ export class Form extends React.PureComponent<IProps, {}> {
 }
 
 // custom validator
-const hasMoreThanFiveChars: ValidationRule = (prop, errorMessage = `${prop} is less than 5 chars`) => [
-    model => model[prop] ? model[prop].length >= 5 : true,
-    { [prop]: errorMessage }
-];
+const hasMoreThanFiveChars: ValidationRule = (
+    prop,
+    errorMessage = `${prop} is less than 5 chars`,
+    type: ValidationType = ValidationType.Error
+) => [model => (model[prop] ? model[prop].length >= 5 : true), { [prop]: errorMessage }, type];
 
 // all validators for the form
 const validators = [
-    isRequired('test'),
-    hasMoreThanFiveChars('test')
+    isRequired('test'), // error by default
+    hasMoreThanFiveChars('test', null, ErrorType.Warning) // optional for warning
 ];
 
 // attaching our Form to form-container with validation

--- a/examples/src/Form.tsx
+++ b/examples/src/Form.tsx
@@ -4,49 +4,58 @@ import JSONTree from 'react-json-tree';
 import * as styles from './form.module.css';
 
 import { isRequired } from '../../src/validators';
+import { ValidationType, ValidationRule } from '../../src/interfaces';
 
 export interface IProps extends IFormProps {}
 
-export const Form: React.SFC<IProps> = props => {
-    const { bindInput } = props.formMethods;
-    console.log('<<<', props);
-    return (
-        <div className={styles.view}>
-            <div className={styles.form}>
-                <h1>Login Form</h1>
-                <form name="login-form">
-                    <label className={styles.label}>
-                        Username:
-                        <input {...bindInput('username')} />
-                        <span className={styles.error}>
-                            {props.form.validationErrors['username']}
-                        </span>
-                    </label>
-                    <label className={styles.label}>
-                        Password:
-                        <input type="password" {...bindInput('password')} />
-                        <span className={styles.error}>
-                            {props.form.validationErrors['password']}
-                        </span>
-                    </label>
-                </form>
-            </div>
-            <div className={styles.json}>
-                <JSONTree data={props.form} />
-            </div>
+export const Form: React.SFC<IProps> = ({
+    form,
+    form: { validationErrors, validationWarnings },
+    formMethods: { bindInput }
+}) => (
+    <div className={styles.view}>
+        <div className={styles.form}>
+            <h1>Login Form</h1>
+            <form name="login-form">
+                <label className={styles.label}>
+                    Username:
+                    <input {...bindInput('username')} />
+                    <span className={styles.error}>{validationErrors['username']}</span>
+                    <span className={styles.warning}>{validationWarnings['username']}</span>
+                </label>
+                <label className={styles.label}>
+                    Password:
+                    <input type="password" {...bindInput('password')} />
+                    <span className={styles.error}>{validationErrors['password']}</span>
+                    <span className={styles.warning}>{validationWarnings['password']}</span>
+                </label>
+            </form>
         </div>
-    );
-};
+        <div className={styles.json}>
+            <JSONTree data={form} />
+        </div>
+    </div>
+);
+
+const hasMoreThanFiveChars: ValidationRule = (
+    prop,
+    errorMessage = `${prop} is less than 5 chars`,
+    type: ValidationType = ValidationType.Error
+) => [model => (model[prop] ? model[prop].length >= 5 : true), { [prop]: errorMessage }, type];
 
 export const ConnectedForm = connectForm<IProps>(
-    [isRequired('username', 'please enter your username')],
+    [
+        isRequired('username', 'please enter your username'), // error by default
+        isRequired('password', 'please enter your password', ValidationType.Error),
+        hasMoreThanFiveChars(
+            'password',
+            'you might want to enter a longer password',
+            ValidationType.Warning
+        )
+    ],
     {
-        middleware: props => {
-            console.log('>>>', props);
-            return {
-                ...props,
-                test: 'one'
-            };
-        }
+        middleware: props => ({
+            ...props
+        })
     }
 )(Form);

--- a/examples/src/form.module.css
+++ b/examples/src/form.module.css
@@ -31,3 +31,7 @@
 .error {
     color: magenta;
 }
+
+.warning {
+    color: yellow;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "form-container",
-    "version": "0.1.5",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-container",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "engines": {
     "node": ">=6.0.0"
   },

--- a/src/FormContainer.tsx
+++ b/src/FormContainer.tsx
@@ -5,7 +5,7 @@ import { IFormConfig, IBoundInput } from './interfaces';
 
 const hoistNonReactStatics = require('hoist-non-react-statics');
 
-const makeWrapper = <T extends {}>(config: IFormConfig) => (WrappedComponent: any) => {
+const makeWrapper = <T extends {}>(config: IFormConfig<T>) => (WrappedComponent: any) => {
     class FormWrapper extends React.Component<any, any> {
         constructor(props: any, context: any) {
             super(props, context);
@@ -92,7 +92,7 @@ const makeWrapper = <T extends {}>(config: IFormConfig) => (WrappedComponent: an
         });
 
         render() {
-            const nextProps = Object.assign({}, this.props, {
+            const nextProps: any = Object.assign({}, this.props, {
                 form: {
                     model: this.state.model,
                     inputs: this.state.inputs,

--- a/src/__tests__/validate.test.tsx
+++ b/src/__tests__/validate.test.tsx
@@ -3,62 +3,127 @@ import * as ReactDOM from 'react-dom';
 import { mount } from 'enzyme';
 import * as validation from '../validate';
 import { isRequired } from '../validators';
+import { ValidationType } from '../interfaces';
 const hoistNonReactStatics = require('hoist-non-react-statics');
 
 describe('Validation', () => {
-  
-  describe('validate', () => {
-    
-    it('should return a valid result of validationFn execution', () => {
-      const MockComponent = ({ formMethods: { bindInput }, form }) => (
-        <form>
-        <input {...bindInput('foo') } />
-        </form>
-      );
-      const props = {
-        form: {
-          model: {
-            foo: 'test'
-          }
-        }
-      };
-      const result = validation.validate([])(MockComponent as any)(props);
-      expect(result.props).toEqual({
-        form: {
-          isValid: true,
-          model: {
-            foo: 'test'
-          },
-          validationErrors: {}
-        }
-      });
+    describe('validate error validator', () => {
+        it('should return a valid result of validationFn execution', () => {
+            const MockComponent = ({ formMethods: { bindInput }, form }) => (
+                <form>
+                    <input {...bindInput('foo')} />
+                </form>
+            );
+            const props = {
+                form: {
+                    model: {
+                        foo: 'test'
+                    }
+                }
+            };
+            const result = validation.validate([isRequired('foo', 'Required field')])(
+                MockComponent as any
+            )(props);
+            expect(result.props).toEqual({
+                form: {
+                    isValid: true,
+                    model: {
+                        foo: 'test'
+                    },
+                    validationErrors: {},
+                    validationWarnings: {}
+                }
+            });
+        });
+
+        it('should return a invalid result of validationFn execution', () => {
+            const MockComponent = ({ formMethods: { bindInput }, form }) => (
+                <form>
+                    <input {...bindInput('foo')} />
+                </form>
+            );
+            const props = {
+                form: {
+                    model: {
+                        foo: ''
+                    }
+                }
+            };
+            const result = validation.validate([isRequired('foo', 'Required field')])(
+                MockComponent as any
+            )(props);
+            expect(result.props).toEqual({
+                form: {
+                    isValid: false,
+                    model: {
+                        foo: ''
+                    },
+                    validationErrors: {
+                        foo: 'Required field'
+                    },
+                    validationWarnings: {}
+                }
+            });
+        });
     });
 
-    it('should return a invalid result of validationFn execution', () => {
-      const MockComponent = ({ formMethods: { bindInput }, form }) => (
-        <form>
-        <input {...bindInput('foo') } />
-        </form>
-      );
-      const props = {
-        form: {
-          model: {
-            foo: ''
-          }
-        }
-      };
-      const result = validation.validate([ isRequired('foo', 'Required field') ])(MockComponent as any)(props);
-      expect(result.props).toEqual({
-        form: {
-          isValid: false,
-          model: {
-            foo: ''
-          },
-          validationErrors: {
-            foo: 'Required field'
-          }
-        }
-      });
+    describe('validate warning validator', () => {
+        it('should return a valid result of validationFn execution', () => {
+            const MockComponent = ({ formMethods: { bindInput }, form }) => (
+                <form>
+                    <input {...bindInput('foo')} />
+                </form>
+            );
+            const props = {
+                form: {
+                    model: {
+                        foo: 'test'
+                    }
+                }
+            };
+            const result = validation.validate([
+                isRequired('foo', 'Required field', ValidationType.Warning)
+            ])(MockComponent as any)(props);
+            expect(result.props).toEqual({
+                form: {
+                    isValid: true,
+                    model: {
+                        foo: 'test'
+                    },
+                    validationErrors: {},
+                    validationWarnings: {}
+                }
+            });
+        });
+
+        it('should return a invalid result of validationFn execution', () => {
+            const MockComponent = ({ formMethods: { bindInput }, form }) => (
+                <form>
+                    <input {...bindInput('foo')} />
+                </form>
+            );
+            const props = {
+                form: {
+                    model: {
+                        foo: ''
+                    }
+                }
+            };
+            const result = validation.validate([
+                isRequired('foo', 'Required field', ValidationType.Warning)
+            ])(MockComponent as any)(props);
+            expect(result.props).toEqual({
+                form: {
+                    isValid: true,
+                    model: {
+                        foo: ''
+                    },
+                    validationErrors: {},
+                    validationWarnings: {
+                        foo: 'Required field'
+                    }
+                }
+            });
+        });
     });
-  });
-})
+});

--- a/src/__tests__/validators.test.ts
+++ b/src/__tests__/validators.test.ts
@@ -1,38 +1,48 @@
 import { ValidationRuleFactory } from '../validators';
+import { ValidationType } from '../interfaces';
 
 describe('Validators', () => {
-  
-  describe('ValidationRuleFactory', () => {
-    let validationFn, rule;
-    
-    beforeEach(() => {
-      validationFn = jest.fn((value: any, allProps: any) => !!value);
-      rule = ValidationRuleFactory(validationFn, 'Error');     
-    });
-    
-    it('should return a result of validationFn execution', () => {
-      const scenarios = [
-        {model: {foo: ''}, result: false},
-        {model: {foo: 'bar'}, result: true}
-      ];
+    describe('ValidationRuleFactory', () => {
+        let validationFn, rule;
 
-      scenarios.forEach(scenario => {
-        const [validate, error] = rule('foo');
-        const allProps = {form: {}};
-        const isValid = validate(scenario.model, allProps);
-        expect(validationFn).toBeCalledWith(scenario.model.foo, allProps);
-        expect(isValid).toBe(scenario.result);
-      });
-    });
+        beforeEach(() => {
+            validationFn = jest.fn((value: any, allProps: any) => !!value);
+            rule = ValidationRuleFactory(validationFn, 'Error');
+        });
 
-    it('should return default error message', () => { 
-      const [validate, error] = rule('foo');
-      expect(error).toEqual({foo: 'Error'});
-    });
+        it('should return a result of validationFn execution', () => {
+            const scenarios = [
+                { model: { foo: '' }, result: false },
+                { model: { foo: 'bar' }, result: true }
+            ];
 
-    it('should return custom error message', () => { 
-      const [validate, error] = rule('foo', 'custom error');
-      expect(error).toEqual({foo: 'custom error'});
+            scenarios.forEach(scenario => {
+                const [validate, error] = rule('foo');
+                const allProps = { form: {} };
+                const isValid = validate(scenario.model, allProps);
+                expect(validationFn).toBeCalledWith(scenario.model.foo, allProps);
+                expect(isValid).toBe(scenario.result);
+            });
+        });
+
+        it('should return default error message', () => {
+            const [validate, error] = rule('foo');
+            expect(error).toEqual({ foo: 'Error' });
+        });
+
+        it('should return custom error message', () => {
+            const [validate, error] = rule('foo', 'custom error');
+            expect(error).toEqual({ foo: 'custom error' });
+        });
+
+        it('should return default error type', () => {
+            const [validate, error, type] = rule('foo');
+            expect(type).toEqual(ValidationType.Error);
+        });
+
+        it('should return warning error type', () => {
+            const [validate, error, type] = rule('foo', null, ValidationType.Warning);
+            expect(type).toEqual(ValidationType.Warning);
+        });
     });
-  });
-})
+});

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 export type ComponentInstance<P = any, S = any> = new () => React.Component<P, S>;
 
 export type Validator = (model: any, allProps?: any) => boolean;
+
 export type ErrorMessage = {
     [name: string]: string | undefined;
 };
@@ -9,8 +10,15 @@ export type ErrorMessage = {
 export type ValidationRule = <T = any>(
     prop: keyof T,
     errorMessage: string,
-    attr?: any
-) => [Validator, ErrorMessage];
+    type?: ValidationType
+) => ValidationRuleResult;
+
+export type ValidationRuleResult = [Validator, ErrorMessage, ValidationType];
+
+export const enum ValidationType {
+    Error = 'error',
+    Warning = 'warning'
+}
 
 export interface IBoundInput {
     name: string;
@@ -35,7 +43,8 @@ export interface IFormProps<T = any> {
         model: any;
         inputs: any;
         isValid?: boolean;
-        validationErrors: { [key: string]: string };
+        validationErrors: { [key in keyof T]: string };
+        validationWarnings: { [key in keyof T]: string };
         touched: { [key: string]: boolean };
     };
     formMethods: IFormMethods<T>;

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,16 +1,18 @@
-import { ValidationRule } from './interfaces';
+import { ValidationRule, ErrorMessage, Validator, ValidationType } from './interfaces';
 
 export const ValidationRuleFactory: any = (
     validationFn: (value: any, allProps?: any) => boolean,
     errorMessage: string
-): ValidationRule => (prop, message = errorMessage) => [
+): ValidationRule => (
+    prop,
+    message = errorMessage,
+    type = ValidationType.Error
+): [Validator, ErrorMessage, ValidationType] => [
     (model, allProps) => validationFn(model[prop], allProps),
-    { [prop]: message }
+    { [prop]: message },
+    type
 ];
 
-export const isRequired: ValidationRule = ValidationRuleFactory(
-    (value: any) => !!value,
-    'Required field'
-);
+export const isRequired = ValidationRuleFactory((value: any) => !!value, 'Required field');
 
-export const hasError: ValidationRule = ValidationRuleFactory((value: any) => false, 'Error');
+export const hasError = ValidationRuleFactory((value: any) => false, 'Error');


### PR DESCRIPTION
#### What's this PR do?
This PR adds the concept of warnings to the project without causing a breaking change. The interface of `formContainer` now simply takes in a type option, like so

```
isRequired('username', 'please enter your username'), // error by default
isRequired('username', 'you might want to enter a username', ValidationType.Warning),
isRequired('password', 'please enter your password', ValidationType.Error)
```

Which generates `validationErrors` _and_ `validationWarnings` in the validate wrapper.

#### Where should the reviewer start?
Probably
* validate.ts
* validators.ts

#### How should this be manually tested?
I've written a few extra tests, which should help. But on top of this I compiled the source and ran it in one of my projects and it seems to work well.

#### What are the relevant tickets / issues?
#33 
