### PR TITLE
setModelTouched

### DIFF
--- a/src/FormContainer.tsx
+++ b/src/FormContainer.tsx
@@ -16,8 +16,17 @@ const makeWrapper = <T extends {}>(config: IFormConfig<T>) => (WrappedComponent:
             };
         }
 
-        setModel = (model: { [name in keyof T]: any }) => {
-            this.setState({ model });
+        setModel = (model: { [name in keyof T]: any }, setTouched: boolean = false) => {
+            let touched: { [key: string]: boolean } = this.state.touched;
+
+            if (!setTouched) {
+                this.setState({ model });
+            } else {
+                for (var field in model) {
+                    touched[field] = true;
+                }
+                this.setState({ model, touched });
+            }
             return model;
         };
 

--- a/src/__tests__/FormContainer.test.tsx
+++ b/src/__tests__/FormContainer.test.tsx
@@ -90,6 +90,27 @@ describe('Form container', () => {
         });
     });
 
+    describe('setModel', () => {
+        it('should set the model and optionally set the touched field', () => {
+            const { wrapperComponent, wrappedComponent } = setupTest();
+            let state: any = wrapperComponent.state();
+
+            const setModel = wrappedComponent.props().formMethods.setModel;
+
+            let data = { foo: 2 };
+            setModel(data);
+            state = wrapperComponent.state();
+            expect(state.model).toEqual(data);
+            expect(state.touched).toEqual({});
+
+            let data = { bar: 1234 };
+            setModel(data, true);
+            state = wrapperComponent.state();
+            expect(state.model).toEqual(data);
+            expect(state.touched).toEqual({ bar: true });
+        });
+    });
+
     describe('bindInput', () => {
         it('should have an input with a name and a value', () => {
             const { input } = setupTest();


### PR DESCRIPTION
#### What's this PR do?
Adds in an optional flag when updating the form model via setModel to mark those fields to be 'touched' - i.e. set the touched object

#### Where should the reviewer start?
FormContainer.tsx

#### Any background context you want to provide?
Was finding that when setting the model after an ajax request, validations and warnings weren't running to reflect the data received.
