### PR TITLE
Add field arrays

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -3674,15 +3674,6 @@
         "minimatch": "3.0.4"
       }
     },
-    "form-container": {
-      "version": "0.2.4-rc11",
-      "resolved": "https://registry.npmjs.org/form-container/-/form-container-0.2.4-rc11.tgz",
-      "integrity": "sha512-N+f57VAOxbU0BqzsT5d3I6nSOrv1Mm/Jc6Ze5DozJ5he1LgXpHM1rh+xjlVEevjdA/nLY5DOumWzKNqWAz0U/g==",
-      "requires": {
-        "hoist-non-react-statics": "2.5.0",
-        "react": "16.2.0"
-      }
-    },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "form-container": "^0.2.4-rc11",
     "material-ui-next": "^1.0.0-beta.38",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/examples/src/Form.tsx
+++ b/examples/src/Form.tsx
@@ -1,9 +1,47 @@
 import * as React from 'react';
 import { connectForm, IFormProps } from 'form-container';
 import { email, required, alphaNumeric, strongPassword } from './validators';
-import { TextField, Button, CardActions, CardHeader, CardContent } from 'material-ui-next';
+import { Button, CardActions, CardHeader, CardContent } from 'material-ui-next';
+import { IBoundInputs } from 'form-container/interfaces';
 
 interface IProps extends IFormProps {}
+
+const Addresses = (bound: IBoundInputs) => {
+    const { fields, ...rest } = bound;
+
+    console.log({ fields });
+
+    return (
+        <div>
+            {fields.map(({ name, values }, index) => {
+                return (
+                    <div key={index}>
+                        <div>
+                            <label>
+                                <span>Address line 1:</span>
+                                <input
+                                    name={`${name}.addressLine1`}
+                                    value={values.addressLine1}
+                                    {...rest}
+                                />
+                            </label>
+                        </div>
+                        <div>
+                            <label>
+                                <span>Address line 2:</span>
+                                <input
+                                    name={`${name}.addressLine2`}
+                                    value={values.addressLine2}
+                                    {...rest}
+                                />
+                            </label>
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
 
 class Form extends React.Component<IProps, {}> {
     handleSubmit = (e: React.SyntheticEvent<any>) => {
@@ -22,31 +60,14 @@ class Form extends React.Component<IProps, {}> {
         this.props.form.touched[prop] && this.props.form.validationErrors[prop];
 
     render() {
-        const { formMethods: { bindInput }, form } = this.props;
+        const { formMethods: { bindInputArray }, form } = this.props;
 
         return (
             <form name="login" onSubmit={this.handleSubmit}>
                 <CardHeader title="Sign in" subheader="form-container example" />
                 <CardContent>
-                    <TextField
-                        style={{ marginBottom: '20px' }}
-                        label="Enter your email"
-                        fullWidth={true}
-                        error={!!this.dirtyInputError('email')}
-                        helperText={this.dirtyInputError('email')}
-                        {...bindInput('email')}
-                    />
-                    <TextField
-                        type="password"
-                        style={{ marginBottom: '20px' }}
-                        label="Enter your password"
-                        fullWidth={true}
-                        error={!!this.dirtyInputError('password')}
-                        helperText={
-                            this.dirtyInputError('password') || form.validationWarnings.password
-                        }
-                        {...bindInput('password')}
-                    />
+                    <Addresses {...bindInputArray('addresses')} />
+                    <div style={{ marginTop: '20px' }}>{JSON.stringify(form.model)}</div>
                 </CardContent>
                 <CardActions>
                     <Button fullWidth={true} type="submit" color="primary" disabled={!form.isValid}>
@@ -66,4 +87,16 @@ const validators = [
     strongPassword('password')
 ];
 
-export const ConnectedForm = connectForm(validators)(Form);
+export const ConnectedForm = connectForm(validators, {
+    initialModel: {
+        addresses: [
+            {
+                addressLine1: '1 Buckingham Palace'
+            },
+            {
+                addressLine1: 'My awesome company',
+                addressLine2: '1 Main Street'
+            }
+        ]
+    }
+})(Form);

--- a/package-lock.json
+++ b/package-lock.json
@@ -329,7 +329,7 @@
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "async-each": {
@@ -428,7 +428,7 @@
         "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.8",
@@ -447,7 +447,7 @@
         "babel-types": "6.26.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       }
@@ -546,7 +546,7 @@
         "babel-runtime": "6.26.0",
         "core-js": "2.5.3",
         "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
       },
@@ -582,7 +582,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "babel-traverse": {
@@ -599,7 +599,7 @@
         "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.3",
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "babel-types": {
@@ -610,7 +610,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "to-fast-properties": "1.0.3"
       }
     },
@@ -915,7 +915,7 @@
         "dom-serializer": "0.1.0",
         "entities": "1.1.1",
         "htmlparser2": "3.9.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "parse5": "3.0.3"
       },
       "dependencies": {
@@ -1587,7 +1587,7 @@
         "function.prototype.name": "1.0.3",
         "has": "1.0.1",
         "is-subset": "0.1.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "object-is": "1.0.1",
         "object.assign": "4.0.4",
         "object.entries": "1.0.4",
@@ -1603,7 +1603,7 @@
       "dev": true,
       "requires": {
         "enzyme-adapter-utils": "1.1.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "object.assign": "4.0.4",
         "object.values": "1.0.4",
         "prop-types": "15.6.0",
@@ -1616,7 +1616,7 @@
       "integrity": "sha512-XU41nEiTl7O2JJvRA7JoCMhkDYRW9mQAgiy67Yz9BqTiRP/ldwuJYX8Gkom2LlihKIb9wy96IDuayR3RQspSNg==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "object.assign": "4.0.4",
         "prop-types": "15.6.0"
       }
@@ -4395,10 +4395,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -5393,9 +5392,9 @@
       }
     },
     "react": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.1.1.tgz",
-      "integrity": "sha512-FQfiFfk2z2Fk87OngNJHT05KyC9DOVn8LPeB7ZX+9u5+yU1JK6o5ozRlU3PeOMr0IFkWNvgn9jU8/IhRxR1F0g==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -5582,7 +5581,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "request-promise-native": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:dev": "npm run test -- --watch",
     "clean": "shx rm -rf _bundles lib lib-esm",
     "build": "rimraf dist && webpack --hide-modules && rimraf dist/ts-build",
+    "build:watch": "rimraf dist && webpack --hide-modules -w && rimraf dist/ts-build",
     "precommit": "pretty-quick --staged",
     "release:next": "npm publish --tag next"
   },
@@ -31,6 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "hoist-non-react-statics": "^2.3.1",
+    "lodash": "^4.17.10",
     "react": "^16.1.0"
   },
   "devDependencies": {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,8 +31,22 @@ export interface IBoundInput {
     ref?: (input: any) => void;
 }
 
+export interface IBoundFields<T = any> {
+    name: string;
+    values: T;
+}
+
+export interface IBoundInputs<T = any> {
+    fields: IBoundFields<T>[];
+    onChange: (e: React.ChangeEvent<any>) => void;
+    onFocus: (e: React.FocusEvent<any>) => void;
+    onBlur: (e: React.FocusEvent<any>) => void;
+    ref?: (input: any) => void;
+}
+
 export interface IFormMethods<T = any> {
     bindInput: (name: keyof T) => IBoundInput;
+    bindInputArray: (name: keyof T) => IBoundInputs;
     bindNativeInput: (name: keyof T) => IBoundInput;
     bindToChangeEvent: (e: React.ChangeEvent<any>) => void;
     setProperty: (prop: keyof T, value: T[keyof T]) => any;


### PR DESCRIPTION
#### What's this PR do?
This pull request **is not ready for merge** but I want to get feedback on this approach of handling field arrays.

An example of the use case for this is multiple addresses. Take a scenario where the user may have to enter their addresses for the past 3 years. As a developer, we would only want to create one instance of the address fields and then render them each time the user needs to input a new address.

Think of a model structure like so...

```
addresses: [
    {
        addressLine1: '1 Buckingham Palace'
    },
    {
        addressLine1: 'My awesome company',
        addressLine2: '1 Main Street'
    }
]
```

Here we would render two address components with the same inputs.

<img width="380" alt="screen shot 2018-05-18 at 10 02 38" src="https://user-images.githubusercontent.com/2536442/40226066-ab11b53a-5a82-11e8-9183-074a288874cc.png">


#### Where should the reviewer start?

Oh God... where to start...

* `setProperty` - I've had to use lodash `set` here so that I can setState with an array key like `addresses[0].addresseLine1`. Any better way of doing this?
* `getValue ` - Again I've had to use lodash `get` here so that I can get a key given an array key like `address[0].addressLine1`. Any better way of doing this?
* `bindInputArray` - I've created this to use when using a field array. The primary difference is that instead of returning `name` and `value` it returns `fields: { name, values }` which can be iterated upon.

And then look at the example Form.tsx for the implementation.


#### How should this be manually tested?
From the root of the project...

```
npm link
cd examples
npm link form-container
npm start
```

#### Further work

The good news is that this _works_, however the inputs are uncontrolled on first render if there is no value and a console error will be emitted the first time this happens. The only way I can see around this is to use something like the `<Control />` component like you suggested in #46 however I wanted to find a way to do this without extra boilerplate.

Also lodash would eventually need to be removed, the example restored and this added as another example, and the code cleaned up in general.

So, feedback on the approach?