### PR TITLE
Add concept of submit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ Form container is a lightweight React form container with validation (written in
 It allows you to use both HTML5 form validation and custom validation functions.
 
 ## TL;DR
-It provides your child form with 2 objects of props:  
+
+It provides your child form with 2 objects of props:
 
 *   `form` - all data on your form values, states, errors and warnings
 *   `formMethods` - methods to bind your input controllers and manipulate the form model
 
 ### Demos:
-- [Material UI login form](https://codesandbox.io/embed/1r1kw355m4)  
-  `form-container` with `material-ui` controls 
+
+*   [Material UI login form](https://codesandbox.io/embed/1r1kw355m4)  
+    `form-container` with `material-ui` controls
 
 ## Installation
 
@@ -157,4 +159,77 @@ const validators = [
 
 // attaching our Form to form-container with validation
 export default connectForm(validators)(Form);
+```
+
+### Submit validation example
+
+Form Container exposes `SubmissionError`, a throwable error which can be used to set submit validation for fields in response to promise rejection because of validation errors.
+
+A wrapped form component has access to `handleSubmit` via `formMethods`:
+
+### `handleSubmit([submit])`
+
+#### Arguments
+
+*   [`submit: (model) => Promise`]: A submit handler function which has access to the form model and returns a Promise.
+
+Inside the provided `submit` function you can throw a `SubmissionError` which will be caught by `handleSubmit`, and the submission errors will be set for each key in the form state under a key `submitErrors`, e.g.:
+
+```javascript
+throw new SubmissionError({
+    test: "Don't like this..."
+});
+```
+
+```javascript
+// components/Form.tsx
+import * as React from 'react';
+import { connectForm, ValidationRuleFactory, Condition, IFormProps } from 'form-container';
+
+interface IProps extends IFormProps {}
+
+interface IFormModel {
+    test: string;
+}
+
+// arbitrary form component
+export class Form extends React.PureComponent<IProps, {}> {
+    submit = (model: IFormModel) => {
+        return fetch('http://dummyurl.com', {
+            method: 'POST',
+            body: model
+        }) // your Promise based HTTP client of choice
+            .catch(error => {
+                const { data: { code }, status } = error.response;
+                if (status === 422 && code === 'xyz') {
+                    throw new SubmissionError({
+                        foo: "Back-end doesn't like this..."
+                    });
+                } else {
+                    /// handle other errors accordingly
+                }
+            });
+    };
+
+    render() {
+        const { validationErrors, submitErrors, touched } = this.props.form;
+        const { bindInput, handleSubmit } = this.props.formMethods;
+        return (
+            <form>
+                <div>
+                    <label>
+                        Test:
+                        <input {...bindInput('test')} />
+                        <small>
+                            {(touched.test && validationErrors.test) || submitErrors.test}
+                        </small>
+                    </label>
+                </div>
+                <button onClick={handleSubmit(this.submit)} />
+            </form>
+        );
+    }
+}
+
+export default connectForm<IFormModel>()(Form);
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1673,6 +1673,11 @@
         "es6-symbol": "3.1.1"
       }
     },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "es6-error": "^4.1.1",
     "hoist-non-react-statics": "^2.3.1",
     "react": "^16.1.0"
   },

--- a/src/SubmissionError.ts
+++ b/src/SubmissionError.ts
@@ -1,0 +1,12 @@
+import ExtendableError from 'es6-error';
+
+export class SubmissionError<T = any> extends ExtendableError {
+    errors: { [key in keyof T]: string };
+
+    constructor(errors: { [key in keyof T]: string }) {
+        super('Submit validation failed');
+        this.errors = errors;
+    }
+}
+
+export default SubmissionError;

--- a/src/__tests__/SubmissionError.test.ts
+++ b/src/__tests__/SubmissionError.test.ts
@@ -1,0 +1,12 @@
+import { SubmissionError } from '../SubmissionError';
+
+describe('SubmissionError', () => {
+    it('should be populated with errors', () => {
+        const errors = {
+            foo: 'Failed'
+        };
+        const submissionError = new SubmissionError(errors);
+
+        expect(submissionError.errors).toEqual(errors);
+    });
+});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,55 @@
+import { omit, isNil, isEmpty, pipe } from '../utils';
+
+describe('utils', () => {
+    describe('omit', () => {
+        const obj = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 };
+
+        it('omits specifed property from given object', () => {
+            expect(omit(obj, 'f')).toEqual({ a: 1, b: 2, c: 3, d: 4, e: 5 });
+        });
+
+        it('ignores invalid properties', () => {
+            expect(omit(obj, 'boo')).toEqual(obj);
+        });
+    });
+
+    describe('isNil', () => {
+        it('returns true if value is `null` or `undefined`', () => {
+            expect(isNil(null)).toEqual(true);
+            expect(isNil(undefined)).toEqual(true);
+            expect(isNil([])).toEqual(false);
+            expect(isNil({})).toEqual(false);
+            expect(isNil(0)).toEqual(false);
+            expect(isNil('')).toEqual(false);
+        });
+    });
+
+    describe('isEmpty', () => {
+        it('returns true for null', () => {
+            expect(isEmpty(null)).toEqual(true);
+        });
+
+        it('returns true for undefined', () => {
+            expect(isEmpty(undefined)).toEqual(true);
+        });
+
+        it('returns true for empty object', () => {
+            expect(isEmpty({})).toEqual(true);
+            expect(isEmpty({ x: 0 })).toEqual(false);
+        });
+    });
+
+    describe('pipe', () => {
+        const multiplyByTwo = (i: number) => i * 2;
+        const addFour = (i: number) => i + 4;
+        const divideByFour = (i: number) => i / 4;
+
+        it('can handle one function argument', () => {
+            expect(pipe(multiplyByTwo)(4)).toEqual(8);
+        });
+
+        it('can handle multiple function arguments', () => {
+            expect(pipe(multiplyByTwo, addFour, divideByFour)(4)).toEqual(3);
+        });
+    });
+});

--- a/src/__tests__/validate.test.tsx
+++ b/src/__tests__/validate.test.tsx
@@ -68,6 +68,40 @@ describe('Validation', () => {
                 }
             });
         });
+
+        it('should return false for isValid where there are submitErrors', () => {
+            const MockComponent = ({ formMethods: { bindInput }, form }) => (
+                <form>
+                    <input {...bindInput('foo')} />
+                </form>
+            );
+            const props = {
+                form: {
+                    model: {
+                        foo: 'boo'
+                    },
+                    submitErrors: {
+                        foo: 'Submit error'
+                    }
+                }
+            };
+            const result = validation.validate([required('foo', 'Required field')])(
+                MockComponent as any
+            )(props);
+            expect(result.props).toEqual({
+                form: {
+                    isValid: false,
+                    model: {
+                        foo: 'boo'
+                    },
+                    submitErrors: {
+                        foo: 'Submit error'
+                    },
+                    validationErrors: {},
+                    validationWarnings: {}
+                }
+            });
+        });
     });
 
     describe('validate warning validator', () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -36,8 +36,10 @@ export interface IFormMethods<T = any> {
     bindNativeInput: (name: keyof T) => IBoundInput;
     bindToChangeEvent: (e: React.ChangeEvent<any>) => void;
     setProperty: (prop: keyof T, value: T[keyof T]) => any;
+    clearSubmitError: (props: keyof T) => void;
     setModel: (model: { [name in keyof T]?: any }) => any;
     setFieldToTouched: (prop: keyof T) => any;
+    handleSubmit: <T = any>(submit: (model: any) => Promise<T>) => () => any;
 }
 
 export interface IFormProps<T = any> {
@@ -45,6 +47,7 @@ export interface IFormProps<T = any> {
         model: any;
         inputs: any;
         isValid?: boolean;
+        submitErrors: { [key in keyof T]: string };
         validationErrors: { [key in keyof T]: string };
         validationWarnings: { [key in keyof T]: string };
         touched: { [key: string]: boolean };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
 export { connectForm } from './FormContainer';
 export { IFormProps, IFormConfig, ValidationRule, ValidationType } from './interfaces';
 export { ValidationRuleFactory } from './validators';
+export { SubmissionError } from './SubmissionError';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,3 +11,12 @@ export const isEmpty = (value: object | null | undefined) => {
 };
 
 export const isNil = (value: any) => value == null;
+
+export const omit = (obj: object, omitKey: string | number | symbol) => {
+    return Object.keys(obj).reduce((result, key) => {
+        if (key !== omitKey) {
+            result[key] = obj[key];
+        }
+        return result;
+    }, {});
+};

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -72,7 +72,7 @@ export const validate = (rules: ValidationRuleResult[] = []) => (
             Object.assign({}, props, {
                 form: {
                     ...props.form,
-                    isValid: isEmpty(validationErrors),
+                    isValid: isEmpty(validationErrors) && isEmpty(props.form.submitErrors),
                     validationErrors,
                     validationWarnings
                 }


### PR DESCRIPTION
#### What's this PR do?

This PR adds the concept of `submitErrors` in component state. This is achieved by adding a throwable `SubmissionError` and `handleSubmit` form method which calls the provided function which returns a promise and catches any thrown `SubmissionError` and sets `submitErrors` in state in response.

#### Where should the reviewer start?

FormContainer.tsx: added `handleSubmit` function which calls provided submit handler and catches and sets any thrown `SubmissionError`s; added logic to setProperty to unset any submitError on the given field
SubmissionError.ts: added throwable `SubmissionError`
validate.ts: update `isValid` prop to  also check is `submitErrors` is empty
interfaces.ts: update FormProps interface

#### How should this be manually tested?

I've added additional tests to cover the added functionality. I have also tested this change with a use-case in our current project where errors need to be set based on the back-end response when adding bank accounts (for invalid format or being a duplicate of an existing entity).

To throw submit errors your submit function provided to handleSubmit would likely look something like this:

```
const options = {
      ...
};

return request(options)
    .then(successHandler)
    .catch(error => {
        const { data, status } = error.response;
        if (status === 422 && data === ...) {
            throw new SubmissionError({
                foo: 'Back-end doesn't like this...',
            });
        }

        ...
    });
```

#### Any background context you want to provide?

See the [associated issue](https://github.com/vitkon/form-container/issues/62) where I have tried my best to articulate the use-case for this.

This solution closely follows the [approach from redux-form](https://redux-form.com/7.4.2/docs/api/submissionerror.md/), you can find a practical example of the usage in Redux Form [here](https://redux-form.com/7.4.2/examples/submitvalidation/).

#### What are the relevant tickets / issues?

#62

#### Questions

Do you think this would be better served by some middleware? I think in this case it would be more difficult to catch and set the submit errors compared to being handled in form-container.